### PR TITLE
Uses variant es-tabla for babel spanish configuration

### DIFF
--- a/PhDThesisPSnPDF.cls
+++ b/PhDThesisPSnPDF.cls
@@ -323,7 +323,7 @@ supported!}
     \message{PhDThesisPSnPDF: Babel American language loaded}
   \else
     \ifPHD@spanish
-      \RequirePackage[spanish]{babel} % Spanish
+      \RequirePackage[spanish,es-tabla]{babel} % Spanish
       \setLanguagetrue
       \setPHDLanguageSpanishtrue
       \message{PhDThesisPSnPDF: Babel Spanish language loaded}


### PR DESCRIPTION
With that variant, the package translates "table" to "tabla" instead of "cuadro", e.g. "Índice de tablas" instead of "Índice de cuadros".